### PR TITLE
fix: move External Secrets Operator from ArgoCD to Ansible Helm deplo…

### DIFF
--- a/infra/k3s/ansible/roles/helm/defaults/main.yml
+++ b/infra/k3s/ansible/roles/helm/defaults/main.yml
@@ -52,6 +52,14 @@ helm_charts:
     chart_version: "5.51.6"
     values_file: "{{ playbook_dir }}/../../helm/argocd/values.yaml"
 
+  - name: external-secrets
+    enabled: true
+    namespace: external-secrets
+    create_namespace: true
+    chart_ref: external-secrets/external-secrets
+    chart_version: "0.9.11"
+    values_file: "{{ playbook_dir }}/../../helm/external-secrets/values.yaml"
+
 ## Helm repositories
 helm_repos:
   - name: bitnami
@@ -60,6 +68,8 @@ helm_repos:
     url: https://helm.elastic.co
   - name: argo
     url: https://argoproj.github.io/argo-helm
+  - name: external-secrets
+    url: https://charts.external-secrets.io
 
 ## Wait for deployments
 helm_wait: true

--- a/infra/k3s/ansible/roles/helm/tasks/main.yml
+++ b/infra/k3s/ansible/roles/helm/tasks/main.yml
@@ -202,6 +202,17 @@
   debug:
     msg: "{{ helm_list.stdout_lines }}"
 
+- name: Wait for external-secrets namespace to be ready
+  kubernetes.core.k8s_info:
+    kind: Namespace
+    name: external-secrets
+    kubeconfig: /etc/rancher/k3s/k3s.yaml
+  register: external_secrets_ns
+  until: external_secrets_ns.resources | length > 0
+  retries: 30
+  delay: 2
+  when: lookup('env', 'DOPPLER_TOKEN') | length > 0
+
 - name: Create Doppler token Secret for External Secrets Operator
   kubernetes.core.k8s:
     state: present

--- a/infra/k3s/argocd/applications/external-secrets.yaml
+++ b/infra/k3s/argocd/applications/external-secrets.yaml
@@ -1,40 +1,6 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
-  name: external-secrets-operator
-  namespace: argocd
-  finalizers:
-    - resources-finalizer.argocd.argoproj.io
-spec:
-  project: default
-  source:
-    repoURL: https://github.com/kangjuhyup/gaegaeting
-    targetRevision: infra
-    path: infra/k3s/helm/external-secrets
-    helm:
-      valueFiles:
-        - values.yaml
-  destination:
-    server: https://kubernetes.default.svc
-    namespace: external-secrets
-  syncPolicy:
-    automated:
-      prune: true
-      selfHeal: true
-      allowEmpty: false
-    syncOptions:
-      - CreateNamespace=true
-      - ServerSideApply=true
-    retry:
-      limit: 5
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 3m
----
-apiVersion: argoproj.io/v1alpha1
-kind: Application
-metadata:
   name: external-secrets-stores
   namespace: argocd
   finalizers:

--- a/infra/k3s/helm/external-secrets/values.yaml
+++ b/infra/k3s/helm/external-secrets/values.yaml
@@ -1,32 +1,31 @@
-external-secrets:
-  ## Install CRDs
-  installCRDs: true
+## Install CRDs
+installCRDs: true
 
-  ## Resources
+## Resources
+resources:
+  requests:
+    cpu: 100m
+    memory: 128Mi
+  limits:
+    cpu: 200m
+    memory: 256Mi
+
+## Webhook resources
+webhook:
   resources:
     requests:
+      cpu: 50m
+      memory: 64Mi
+    limits:
       cpu: 100m
       memory: 128Mi
+
+## Cert controller resources
+certController:
+  resources:
+    requests:
+      cpu: 50m
+      memory: 64Mi
     limits:
-      cpu: 200m
-      memory: 256Mi
-
-  ## Webhook resources
-  webhook:
-    resources:
-      requests:
-        cpu: 50m
-        memory: 64Mi
-      limits:
-        cpu: 100m
-        memory: 128Mi
-
-  ## Cert controller resources
-  certController:
-    resources:
-      requests:
-        cpu: 50m
-        memory: 64Mi
-      limits:
-        cpu: 100m
-        memory: 128Mi
+      cpu: 100m
+      memory: 128Mi


### PR DESCRIPTION
…yment

ArgoCD Application으로 External Secrets Operator를 배포하면 GitHub Actions에서 Doppler token Secret을 미리 주입할 수 없는 문제를 해결하기 위해 Ansible Helm 태스크로 이동. 이제 Ansible이 Operator를 설치하고 Secret을 생성한 후, ArgoCD는 ClusterSecretStore와 ExternalSecret 리소스만 관리.

🤖 Generated with [Claude Code](https://claude.com/claude-code)