### PR TITLE
fix: install External Secrets CRDs manually to avoid Helm ownership c…

### DIFF
--- a/infra/k3s/ansible/roles/helm/tasks/main.yml
+++ b/infra/k3s/ansible/roles/helm/tasks/main.yml
@@ -141,6 +141,15 @@
     - item.enabled | default(true)
     - item.create_namespace | default(false)
 
+- name: Install External Secrets CRDs manually
+  shell: |
+    kubectl apply -f https://raw.githubusercontent.com/external-secrets/external-secrets/v0.9.11/deploy/crds/bundle.yaml --server-side --force-conflicts
+  environment:
+    KUBECONFIG: /etc/rancher/k3s/k3s.yaml
+  register: crds_install
+  changed_when: "'created' in crds_install.stdout or 'configured' in crds_install.stdout"
+  failed_when: false
+
 - name: Deploy Helm charts
   kubernetes.core.helm:
     name: "{{ item.name }}"

--- a/infra/k3s/helm/external-secrets/values.yaml
+++ b/infra/k3s/helm/external-secrets/values.yaml
@@ -1,5 +1,5 @@
 ## Install CRDs
-installCRDs: true
+installCRDs: false
 
 ## Resources
 resources:


### PR DESCRIPTION
…onflicts

기존 ArgoCD로 설치된 CRD와 Helm 간의 ownership metadata 충돌을 해결하기 위해 CRD를 Helm 외부에서 수동으로 설치. kubectl apply --server-side --force-conflicts 옵션으로 기존 CRD가 있어도 충돌 없이 적용 가능.

🤖 Generated with [Claude Code](https://claude.com/claude-code)