### PR TITLE
feat: add MySQL ExternalSecret for Doppler integration

### DIFF
--- a/infra/k3s/applications/mysql/external-secret.yaml
+++ b/infra/k3s/applications/mysql/external-secret.yaml
@@ -1,0 +1,23 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: mysql-secrets
+  namespace: database
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: doppler
+    kind: ClusterSecretStore
+  target:
+    name: mysql-secrets
+    creationPolicy: Owner
+  data:
+    - secretKey: mysql-root-password
+      remoteRef:
+        key: MYSQL_ROOT_PASSWORD
+    - secretKey: mysql-password
+      remoteRef:
+        key: MYSQL_PASSWORD
+    - secretKey: mysql-replication-password
+      remoteRef:
+        key: MYSQL_REPLICATION_PASSWORD


### PR DESCRIPTION
MySQL Application이 Doppler에서 비밀번호를 가져올 수 있도록 ExternalSecret 생성. ClusterSecretStore를 통해 MYSQL_ROOT_PASSWORD, MYSQL_PASSWORD, MYSQL_REPLICATION_PASSWORD를 자동으로 주입.

🤖 Generated with [Claude Code](https://claude.com/claude-code)