### PR TITLE
fix: change MySQL probes from exec to tcpSocket

### DIFF
--- a/infra/k3s/applications/mysql/base/mysql-master-sts.yaml
+++ b/infra/k3s/applications/mysql/base/mysql-master-sts.yaml
@@ -63,22 +63,16 @@ spec:
               memory: "2Gi"
               cpu: "2000m"
           livenessProbe:
-            exec:
-              command:
-                - sh
-                - -c
-                - mysqladmin status -uroot -p$MYSQL_ROOT_PASSWORD
+            tcpSocket:
+              port: 3306
             initialDelaySeconds: 30
             periodSeconds: 10
             timeoutSeconds: 5
             successThreshold: 1
             failureThreshold: 3
           readinessProbe:
-            exec:
-              command:
-                - sh
-                - -c
-                - mysqladmin status -uroot -p$MYSQL_ROOT_PASSWORD
+            tcpSocket:
+              port: 3306
             initialDelaySeconds: 15
             periodSeconds: 10
             timeoutSeconds: 5

--- a/infra/k3s/applications/mysql/base/mysql-replica-sts.yaml
+++ b/infra/k3s/applications/mysql/base/mysql-replica-sts.yaml
@@ -63,22 +63,16 @@ spec:
               memory: "2Gi"
               cpu: "2000m"
           livenessProbe:
-            exec:
-              command:
-                - sh
-                - -c
-                - mysqladmin status -uroot -p$MYSQL_ROOT_PASSWORD
+            tcpSocket:
+              port: 3306
             initialDelaySeconds: 30
             periodSeconds: 10
             timeoutSeconds: 5
             successThreshold: 1
             failureThreshold: 3
           readinessProbe:
-            exec:
-              command:
-                - sh
-                - -c
-                - mysqladmin status -uroot -p$MYSQL_ROOT_PASSWORD
+            tcpSocket:
+              port: 3306
             initialDelaySeconds: 15
             periodSeconds: 10
             timeoutSeconds: 5


### PR DESCRIPTION
Environment variables not accessible in exec probes, causing authentication failures. Using tcpSocket probe on port 3306 instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)