### PR TITLE
ci: make apt cache refresh more resilient

### DIFF
--- a/infra/k3s/ansible/playbooks/site.yml
+++ b/infra/k3s/ansible/playbooks/site.yml
@@ -9,6 +9,9 @@
       apt:
         update_cache: true
         cache_valid_time: 3600
+        update_cache_retries: 10
+        update_cache_retry_max_delay: 30
+        lock_timeout: 120
       when: ansible_os_family == "Debian"
       
     - name: Update yum cache


### PR DESCRIPTION
## Summary
- Increase apt cache update retries for the k3s Ansible pre-task
- Add retry max delay and apt lock timeout to reduce transient deploy failures

## Context
The K3s Cluster Deploy workflow failed before Istio deployment at the `Update apt cache` pre-task on `k3s-master`.

## Verification
- `ruby -e 'require "yaml"; YAML.load_file("infra/k3s/ansible/playbooks/site.yml"); puts "ok"'`