### PR TITLE
ci: harden apt package install retries

### DIFF
--- a/infra/k3s/ansible/roles/helm/tasks/main.yml
+++ b/infra/k3s/ansible/roles/helm/tasks/main.yml
@@ -4,6 +4,9 @@
     name: python3-pip
     state: present
     update_cache: true
+    update_cache_retries: 10
+    update_cache_retry_max_delay: 30
+    lock_timeout: 120
   become: true
 
 - name: Install kubernetes Python library

--- a/infra/k3s/ansible/roles/system/tasks/main.yml
+++ b/infra/k3s/ansible/roles/system/tasks/main.yml
@@ -5,10 +5,21 @@
   notify: restart cron
 
 - name: Install required packages
-  package:
+  apt:
     name: "{{ packages.install }}"
     state: present
     update_cache: "{{ packages.update_cache | default(true) }}"
+    update_cache_retries: 10
+    update_cache_retry_max_delay: 30
+    lock_timeout: 120
+  when: ansible_os_family == "Debian"
+
+- name: Install required packages
+  yum:
+    name: "{{ packages.install }}"
+    state: present
+    update_cache: "{{ packages.update_cache | default(true) }}"
+  when: ansible_os_family == "RedHat"
   
 - name: Upgrade all packages
   package:


### PR DESCRIPTION
## Summary
- Use Debian-specific `apt` for required package installation so retry/lock options can be applied
- Keep RedHat package installation on `yum`
- Add apt cache retry, max delay, and lock timeout to the helm role pip install prerequisite

## Context
The K3s deploy workflow passed the initial apt cache pre-task, then failed again at `system : Install required packages` while refreshing apt cache.

## Verification
- `ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f); puts f }' infra/k3s/ansible/roles/system/tasks/main.yml infra/k3s/ansible/roles/helm/tasks/main.yml`