### PR TITLE
ci: skip duplicate apt cache refresh during installs

### DIFF
--- a/infra/k3s/ansible/roles/helm/tasks/main.yml
+++ b/infra/k3s/ansible/roles/helm/tasks/main.yml
@@ -3,9 +3,7 @@
   apt:
     name: python3-pip
     state: present
-    update_cache: true
-    update_cache_retries: 10
-    update_cache_retry_max_delay: 30
+    update_cache: false
     lock_timeout: 120
   become: true
 

--- a/infra/k3s/ansible/roles/system/tasks/main.yml
+++ b/infra/k3s/ansible/roles/system/tasks/main.yml
@@ -8,9 +8,7 @@
   apt:
     name: "{{ packages.install }}"
     state: present
-    update_cache: "{{ packages.update_cache | default(true) }}"
-    update_cache_retries: 10
-    update_cache_retry_max_delay: 30
+    update_cache: false
     lock_timeout: 120
   when: ansible_os_family == "Debian"
 


### PR DESCRIPTION
## Summary
- Stop refreshing apt cache inside package install tasks after the playbook pre-task already handles cache refresh
- Keep apt lock timeout for package installation
- Apply the same duplicate cache refresh skip to the helm role's `python3-pip` prerequisite

## Context
The K3s deploy workflow keeps failing at `system : Install required packages` while refreshing apt cache, even after increasing retry counts. This narrows apt cache refresh to the pre-task and lets install tasks use the already prepared cache.

## Verification
- `ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f); puts f }' infra/k3s/ansible/roles/system/tasks/main.yml infra/k3s/ansible/roles/helm/tasks/main.yml`